### PR TITLE
ci(pages): deploy only from main

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -2,13 +2,17 @@ name: Deploy Frontend to GitHub Pages
 
 on:
   push:
-    branches: [ main, prod, stage ]
+    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   build-and-deploy:
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
- Limit Pages deploy workflow to main only (no stage/prod)\n- Add workflow_dispatch for manual redeploys\n- Add concurrency guard to avoid race deploys\n\nThis ensures https://bradleymatera.github.io/car-match always reflects main.