### PR TITLE
docs: September log + docs refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Owner: Bradley Matera — [Log](./docs/log.md)
 - Troubleshooting: [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md)
 - Designs: [docs/designs](./docs/designs)
  - Health: `GET /healthz` on the backend returns service/db readiness
+ - Current Monthly Log: [docs/2025-09.md](./docs/2025-09.md)
 
 ## Quick Start (Local)
 

--- a/docs/2025-09.md
+++ b/docs/2025-09.md
@@ -1,0 +1,44 @@
+# Car Match — September 2025 Log
+
+Date: 2025-09-12 (Friday, Week 2)
+Owner: Bradley Matera
+
+## Week 1
+
+Overview:
+- Frontend is stable and live on GitHub Pages with the forums UI, a standalone messages page, and auth/events all working against the backend.
+- Backend security tightened with CORS allowlisting and JWT token rotation/versioning.
+- Forums endpoints added with Mongoose models (working locally).
+
+Accomplishments:
+- GH Pages deploy + Render blueprint working.
+- Repo docs refreshed across frontend, backend, and deployment guides.
+
+Challenges:
+- Forums in prod showed “Database not available” because the Mongo URI wasn’t formatted/encoded correctly.
+
+Next Steps:
+- Fix MongoDB connection string on Render, redeploy, and confirm `/healthz` shows `connected: true` and forums persist in prod.
+
+## Week 2 (in progress)
+
+Focus:
+- Combine settings into real features and consolidate them into the Profile page (remove separate Settings tab from the header).
+- Make the Profile page UI/UX cleaner; “My Events” should only show events created by me or RSVP’d to (not the full list).
+
+Notes:
+- Events and Forums UI/UX are largely finished. The backend still needs a moderation system (roles/tiering like admin/mod) and stronger event–user ownership across the stack.
+
+Status (Fri):
+- On schedule. GH Pages now deploys only from `main`; prod deploy verified. MongoDB URI and forum persistence validation underway.
+
+## Tracking Snapshot
+
+- Issues / Board: All Week 1/2 items are filed and placed on the project board with correct status (Backlog, In Progress, In Review, Done). Open “Done” items were moved out of Done.
+- Milestones: “Sept Wk 2” for in‑progress work; “Sept Wk 3/4” for backlog/follow‑ups.
+- Change Orders: `docs/research/ChangeOrders.md` updated (CO‑001 through CO‑007).
+
+References
+- Live App (Pages): https://bradleymatera.github.io/car-match/
+- Backend health: GET /healthz (Render)
+- Repo: https://github.com/BradleyMatera/car-match

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -9,7 +9,7 @@ Frontend (GitHub Pages)
 - Repo Variables (Settings → Secrets and variables → Actions → Variables):
   - `REACT_APP_API_BASE_URL`: your backend base URL (Render)
   - `REACT_APP_USE_REAL_EVENTS=true`: fetch events from backend (mock kept for demo richness otherwise)
-- On push to `main`, `prod`, or `stage`, the workflow builds `frontend` and deploys `frontend/build`.
+- Deploys from `main` only. You can also trigger a manual run via Actions (workflow_dispatch).
 - App URL: `https://bradleymatera.github.io/car-match/`
 
 Backend (Render example)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,36 +1,29 @@
-# Car Match – A Dating Platform for Car Enthusiasts
+# Car Match — Documentation
 
-Car Match is a concept-first dating platform designed specifically for car lovers of all kinds—muscle cars, JDM, luxury vehicles, and more. This is not just a frontend mockup. The entire structure is built as a real MVP that simulates full app behavior using mocked data and realistic frontend logic, ready to plug into a real backend.
+Car Match is a community app for car enthusiasts — events, forums, messaging, and profiles. This repo contains a working React frontend (deployed to GitHub Pages) and a Node/Express backend (deployable on Render) with optional MongoDB persistence for forums and other data.
 
 ## Tech Stack
 
-- **Frontend**: HTML, CSS, JavaScript (Vanilla, planning React or framework later)
-- **Layout System**: Custom responsive grid using Flexbox/Grid with media queries
-- **State**: Vanilla JS with `localStorage` for simulated login/session handling
-- **Repository**: [GitHub - BradleyMatera/car-match](https://github.com/BradleyMatera/car-match)
-- **Deployment**: Coming soon (Netlify or Vercel after MVP polish)
+- Frontend: React (CRA), React Router (HashRouter for Pages), plain CSS.
+- Backend: Node.js + Express 5, JWT auth, CORS hardening.
+- Database: MongoDB Atlas via Mongoose (forums persist when `MONGODB_URI` is set; otherwise in-memory).
+- CI/CD: GitHub Actions deploys frontend to Pages; Render blueprint for backend.
 
-## MVP Overview
+## Key Links
 
-- Homepage modal intro (gated access flow)
-- Full form-based onboarding
-- Mock data for users, events, and interactions
-- Structured like a real production-ready frontend
-- Focus on UI/UX, accessibility, and mobile-first design
-- Reorganizing editable controls into settings for proper flow
-- Calendar, RSVP simulation, discussion feed on Events page
-- All layouts tested for real responsiveness
+- Live App: https://bradleymatera.github.io/car-match/
+- API/Backend: see `docs/API.md`
+- Deployment: `docs/DEPLOYMENT.md` (Pages + Render)
+- Troubleshooting: `docs/TROUBLESHOOTING.md`
+- Research & Change Orders: `docs/research/` (see `ChangeOrders.md`)
+- Monthly Log (September 2025): `docs/2025-09.md`
 
-## In Progress
+## Status (September 2025)
 
-- Conversion of `designdoc.md` into GitHub markdown files inside `/docs/research`
-- Full migration of weekly standups into Issues/Milestones
-- MVP UI polishing and error handling
-- Research 1 being documented actively (due Sunday)
-- Issue and project automation planned per Full Sail course structure
+- Pages deploys only from `main`.
+- Forums persist in prod when MongoDB URI is correctly URL‑encoded and configured on Render.
+- Week 2 focus: consolidate Settings into the Profile page; Profile UX polish; finalize forum persistence checks in prod.
 
 ## Notes
 
-This repo uses a proper feature branch workflow per class instructions. Feature branches will merge into `dev`, then into `stage`, and only into `main` with approval or final submissions.
-
-If you're reviewing this for grading or feedback, please check the `/docs/research` folder and the active design work inside `designdoc.md`.
+Standard workflow uses PRs into `dev` and promotion to `main`. GitHub Pages publishes from `main` only.


### PR DESCRIPTION
- Add September 2025 monthly log (Week 1 + Week 2 in progress)\n- Update docs README to reflect React/Express stack and current status\n- Deployment docs: Pages deploy from main only\n- Link current monthly log from root README