### PR TITLE
wk2: close out #60, #62, #65

### DIFF
--- a/docs/2025-09.md
+++ b/docs/2025-09.md
@@ -30,7 +30,7 @@ Notes:
 - Events and Forums UI/UX are largely finished. The backend still needs a moderation system (roles/tiering like admin/mod) and stronger event–user ownership across the stack.
 
 Status (Fri):
-- On schedule. GH Pages now deploys only from `main`; prod deploy verified. MongoDB URI and forum persistence validation underway.
+- On schedule. GH Pages now deploys only from `main` (live verified). MongoDB URI fixed on Render and `/healthz` reports `connected: true`; forum stats confirm persistence. “My Events” now correctly shows only events I created or RSVP’d to. Project hygiene complete (board, milestones, roadmap).
 
 ## Tracking Snapshot
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,11 @@ Car Match is a community app for car enthusiasts — events, forums, messaging, 
 - Research & Change Orders: `docs/research/` (see `ChangeOrders.md`)
 - Logs: `docs/log.md` (original, May), `docs/log2.md` (September), and monthly snapshot `docs/2025-09.md`
 
+## Project Ops
+
+- Project board helper: `scripts/update_project.sh` (adds issues to Project, helps update Status fields)
+- Roadmap population (dates/status): see Project updates in the repo history; items have Start/End dates based on issue activity and sprint due dates.
+
 ## Status (September 2025)
 
 - Pages deploys only from `main`.

--- a/frontend/src/api/mockApi.js
+++ b/frontend/src/api/mockApi.js
@@ -115,8 +115,9 @@ const api = {
       api.getEvents(),
       token ? api.getMyRsvps(token) : Promise.resolve([]),
     ]);
-    const rsvpIds = new Set(mine.map(r => r.eventId));
-    return all.filter(e => e.createdByUserId === userId || rsvpIds.has(e.id));
+    const uid = String(userId);
+    const rsvpIds = new Set((mine || []).map(r => String(r.eventId)));
+    return (all || []).filter(e => String(e.createdByUserId) === uid || rsvpIds.has(String(e.id)));
   },
 
   // --- Forums ---


### PR DESCRIPTION
- #60 CO-001 MongoDB URI fixed on Render; /healthz shows connected:true; forums persistence confirmed via /forums/stats.\n- #62 Profile: "My Events" now filters by createdByUserId or RSVP (string-safe).\n- #65 Project hygiene done: board normalized, milestones set (Wk1–Wk4), Roadmap dates/status populated.\n- Updated docs: docs/2025-09.md status, docs/README.md ops notes.