### PR TITLE
chore: suppress extension-originated console error in prod

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -16,3 +16,18 @@ root.render(
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();
+
+// Suppress noisy extension-originated Promise errors in production only.
+// This does NOT mask real app errors; it filters a known Chrome extension message
+// "A listener indicated an asynchronous response by returning true, but the message channel closed..."
+if (process && process.env && process.env.NODE_ENV === 'production') {
+  window.addEventListener('unhandledrejection', (event) => {
+    try {
+      const reason = event && event.reason;
+      const msg = (reason && (reason.message || String(reason))) || '';
+      if (msg.includes('A listener indicated an asynchronous response')) {
+        event.preventDefault();
+      }
+    } catch (_) { /* ignore */ }
+  });
+}


### PR DESCRIPTION
Ignore the known Chrome extension error "A listener indicated an asynchronous response..." via a production-only unhandledrejection filter. This does not affect real app errors and avoids confusing logs in production.