### PR TITLE
feat: Merge Settings into Profile (Issue #61)

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -21,6 +21,36 @@ const CarSchema = new mongoose.Schema({
   photos: [String],
 }, { _id: false });
 
+const PreferencesNotificationsSchema = new mongoose.Schema({
+  messagesEmail: { type: Boolean, default: true },
+  forumRepliesEmail: { type: Boolean, default: true },
+  eventRemindersEmail: { type: Boolean, default: true },
+}, { _id: false });
+
+const PreferencesPrivacySchema = new mongoose.Schema({
+  showProfile: { type: Boolean, default: true },
+  showEmail: { type: Boolean, default: false },
+  searchable: { type: Boolean, default: true },
+}, { _id: false });
+
+const PreferencesDisplaySchema = new mongoose.Schema({
+  theme: { type: String, enum: ['light','dark','system'], default: 'system' },
+  textSize: { type: String, enum: ['normal','large'], default: 'normal' },
+}, { _id: false });
+
+const ConnectionsSchema = new mongoose.Schema({
+  instagram: String,
+  twitter: String,
+  website: String,
+}, { _id: false });
+
+const PreferencesSchema = new mongoose.Schema({
+  notifications: { type: PreferencesNotificationsSchema, default: () => ({}) },
+  privacy: { type: PreferencesPrivacySchema, default: () => ({}) },
+  display: { type: PreferencesDisplaySchema, default: () => ({}) },
+  connections: { type: ConnectionsSchema, default: () => ({}) },
+}, { _id: false });
+
 const UserSchema = new mongoose.Schema({
   mockId: String, // e.g., 'user1' from mock data
   username: { type: String, index: true, unique: true },
@@ -39,6 +69,7 @@ const UserSchema = new mongoose.Schema({
   cars: [CarSchema],
   role: { type: String, default: 'user' },
   createdAt: { type: Date, default: Date.now },
+  preferences: { type: PreferencesSchema, default: () => ({}) },
 });
 
 // Enforce email uniqueness only when email exists

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -33,7 +33,7 @@ function AppContent() {
               <li><Link to="/forums">Forums</Link></li>
               {/* Messages moved under Profile; remove header link */}
               <li><Link to="/profile">Profile</Link></li>
-              <li><Link to="/settings">Settings</Link></li>
+              {/* Settings merged into Profile */}
               <li><button onClick={logout} className="logout-button">Logout</button></li>
             </ul>
           </nav>

--- a/frontend/src/api/mockApi.js
+++ b/frontend/src/api/mockApi.js
@@ -168,6 +168,13 @@ const api = {
   toggleDevOverride: async (token, userId) =>
     ok(await fetch(`${API_BASE_URL}/users/${userId}/toggle-dev-override`, { method: 'PUT', headers: { ...jsonHeader, ...authHeader(token) } })).then(json),
 
+  // --- Account / Settings ---
+  getMe: async (token) => ok(await fetch(`${API_BASE_URL}/users/me`, { headers: { ...authHeader(token) } })).then(json),
+  updateUser: async (token, userId, data) =>
+    ok(await fetch(`${API_BASE_URL}/users/${encodeURIComponent(userId)}`, { method: 'PATCH', headers: { ...jsonHeader, ...authHeader(token) }, body: JSON.stringify(data) })).then(json),
+  deleteUser: async (token, userId) =>
+    ok(await fetch(`${API_BASE_URL}/users/${encodeURIComponent(userId)}`, { method: 'DELETE', headers: { ...authHeader(token) } })).then(json),
+
   // --- Legacy shims (no mocks) ---
   initMockData: () => Promise.resolve(),
   getMessages: async () => [],


### PR DESCRIPTION
- Remove Settings link; integrate settings UI into Profile\n- Add user preferences (notifications, privacy, display, connections) to schema\n- Backend: GET /users/me, PATCH /users/:id, DELETE /users/:id\n- Frontend: Save settings to backend; add Danger Zone (delete account)\n- Keep payments realistic: Upgrade to Premium uses existing endpoint\n\nThis makes settings real using the existing Render backend + Mongo Atlas.