### PR TITLE
fix(ci): ESLint cleanup for Pages build

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,7 +4,7 @@ import './App.css';
 import Home from './components/Home';
 import Events from './components/Events';
 import Profile from './components/Profile';
-import Settings from './components/Settings';
+// Settings merged into Profile; route removed
 import Forums from './components/Forums';
 // import EntryModal from './components/EntryModal'; // Replaced by SignUp component for /signup route
 import SignUp from './components/SignUp'; // Import the new SignUp component
@@ -54,7 +54,7 @@ function AppContent() {
               <Route path="/forums" element={<Layout><Forums /></Layout>} />
               {/* Messages page removed; handled within Profile */}
               <Route path="/profile" element={<Layout><Profile /></Layout>} />
-              <Route path="/settings" element={<Layout><Settings /></Layout>} />
+              {/* Settings merged into Profile; route removed */}
               <Route path="/layout-example" element={<Layout><LayoutExample /></Layout>} />
               <Route path="*" element={<Navigate to="/" />} />
             </>

--- a/frontend/src/components/Profile/index.js
+++ b/frontend/src/components/Profile/index.js
@@ -197,16 +197,7 @@ const Profile = () => {
     }
   };
 
-  const handleToggleDevOverride = async () => {
-    if (!currentUser || !token) return;
-    try {
-      const updatedUserData = await mockApi.toggleDevOverride(token, currentUser.id);
-      updateCurrentUser(updatedUserData.user);
-      alert(`Developer override set to: ${updatedUserData.user.developerOverride}.`);
-    } catch (error) {
-      alert(`Failed to toggle dev override: ${error.message}`);
-    }
-  };
+  // Dev override removed from UI; no handler needed.
 
   const handleReply = (messageToReplyTo) => {
     if (!isEffectivelyPremium && messageToReplyTo.isLocked) {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -20,7 +20,7 @@ reportWebVitals();
 // Suppress noisy extension-originated Promise errors in production only.
 // This does NOT mask real app errors; it filters a known Chrome extension message
 // "A listener indicated an asynchronous response by returning true, but the message channel closed..."
-if (process && process.env && process.env.NODE_ENV === 'production') {
+if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') {
   window.addEventListener('unhandledrejection', (event) => {
     try {
       const reason = event && event.reason;


### PR DESCRIPTION
- Remove unused handleToggleDevOverride in Profile\n- Guard process env check in index.js for eslint\n- Remove Settings route/import (settings merged into Profile)\n\nThis unblocks CI (CI=true) build warnings-as-errors.