### PR TITLE
feat(forums): role-based moderation backend

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -67,12 +67,13 @@ const UserSchema = new mongoose.Schema({
   profileImage: String,
   carInterests: [String],
   cars: [CarSchema],
-  role: { type: String, default: 'user' },
+  role: { type: String, enum: ['user', 'moderator', 'admin'], default: 'user' },
   createdAt: { type: Date, default: Date.now },
   preferences: { type: PreferencesSchema, default: () => ({}) },
 });
 
 // Enforce email uniqueness only when email exists
 UserSchema.index({ email: 1 }, { unique: true, partialFilterExpression: { email: { $type: 'string' } } });
+UserSchema.index({ role: 1 });
 
 module.exports = mongoose.models.User || mongoose.model('User', UserSchema);

--- a/backend/scripts/seedFromMock.js
+++ b/backend/scripts/seedFromMock.js
@@ -39,6 +39,7 @@ async function main() {
       location: mu.location,
       premiumStatus: !!mu.premiumStatus,
       developerOverride: !!mu.developerOverride,
+      role: mu.role && ['user','moderator','admin'].includes(mu.role) ? mu.role : (mu.developerOverride ? 'admin' : 'user'),
       activityMetadata: mu.activityMetadata || { messageCountToday: 0, lastMessageDate: null },
       biography: prof?.bio || '',
       carInterests: prof?.carInterests || [],

--- a/docs/log2.md
+++ b/docs/log2.md
@@ -84,11 +84,9 @@ Opened Milestone `359 MS 10`, kept the `dev → staging` rollup PR active, and b
 🏆 Accomplishments:  
 - Updated milestone metadata and project board to reflect the current sprint.
 - Added research summaries + rollout plans to the master log and epics without spawning new docs.
-- Implemented backend ownership enforcement (schema, RSVP/comment, backfill) and opened PR #133 
 - Implemented backend ownership enforcement (schema, RSVP/comment, backfill) and opened PR #133.
-- Replaced the frontend `mockApi` imports with the real API client (`client.js`) so all flows call the live backend; prepping UI follow-ups.
-- Implemented backend ownership enforcement (schema, RSVP/comment, backfill) and opened PR #133.
-- Replaced the frontend `mockApi` imports with the real API client (`client.js`) so all flows call the live backend; prepping UI follow-ups.
+- Replaced the frontend `mockApi` imports with the real API client (`client.js`) so all flows call the live backend.
+- Hardened forum moderation backend (role enum, admin role assignment API, moderation logging/limits) and synced Atlas via `/admin/backfill-events-users`.
 - Merged documentation PR #131 after verifying the workflow through feature branch → dev.
 
 🔮 Next Steps:  


### PR DESCRIPTION
## Summary
- constrain `User.role` to an enum and surface role metadata through login/JWT/auth middleware
- add `/admin/users/:userId/role` for role assignment, seed default admin, and tighten forum moderation endpoints with logging + rate limiting
- log the backend progress in `docs/log2.md` and run the Atlas backfill via authenticated admin to normalize event ownership

## Testing
- not run (manual moderation smoke tests planned post-merge)